### PR TITLE
loosen unnecessary ABI restriction

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,7 @@ set_target_properties(alut
 	VERSION
 	${MAJOR_VERSION}
 	SOVERSION
-	${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_VERSION})
+	${MAJOR_VERSION})
 target_link_libraries(alut ${OPENAL_LIBRARY})
 if(UNIX)
 	target_link_libraries(alut m)


### PR DESCRIPTION
[issue reported by Michael Zeilfelder]

-given the low level of development seen on this library, such a
restrictive SOVERSION is unnecessary. changes to ABI would usually
entail a bump at the MAJOR_VERSION level, not the BUILD_VERSION
level
-currently, cmake builds won't be a drop in replacement for consumers
of existing builds, who will be forced to rebuild whole applications
unnecessarily

pre-commit

> readelf -a ./libalut.so.0.1.0 | grep SONAME -
>  0x000000000000000e (SONAME)      Library soname: [libalut.so.0.1.0]
> post-commit
> readelf -a ./libalut.so.0.1.0 | grep SONAME -
>  0x000000000000000e (SONAME)      Library soname: [libalut.so.0]
