### PR TITLE
Remove Cmake static library workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories(${Alut_SOURCE_DIR}/include)
 
 # What to build?
 option(BUILD_EXAMPLES "build example applications" ON)
-option(BUILD_STATIC "build static library too" OFF)
+option(BUILD_SHARED_LIBS "build freealut as a shared library rather than a static library" ON)
 option(BUILD_TESTS "build the test-suite" ON)
 
 # How to build it?

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,35 +39,7 @@ set(ALUT_HEADERS
 	../include/AL/alut.h)
 source_group(APIHeader FILES ${ALUT_HEADERS})
 
-
-if(BUILD_STATIC)
-	# we can't create a static library with the same name
-	# as the shared one, so we copy it over after creation
-	add_library(alut_static STATIC ${ALUT_SOURCES} ${ALUT_INTERNAL_HEADERS} ${ALUT_HEADERS})
-	target_link_libraries(alut_static ${OPENAL_LIBRARY} ${ADD_LIBS})
-	if(UNIX)
-		target_link_libraries(alut_static m)
-	endif()	
-	if(NOT WIN32)
-		# TODO this is an inelegant hack...
-		add_custom_command(TARGET
-			alut_static
-			POST_BUILD
-			COMMAND
-			${CMAKE_COMMAND}
-			ARGS
-			-E
-			copy
-			${CMAKE_BINARY_DIR}/src/${CMAKE_STATIC_LIBRARY_PREFIX}alut_static${CMAKE_STATIC_LIBRARY_SUFFIX}
-			${CMAKE_BINARY_DIR}/src/${CMAKE_STATIC_LIBRARY_PREFIX}alut${CMAKE_STATIC_LIBRARY_SUFFIX})
-		install_files(/lib${LIB_SUFFIX}
-			FILES
-			${CMAKE_STATIC_LIBRARY_PREFIX}alut${CMAKE_STATIC_LIBRARY_SUFFIX})
-	endif()
-endif()
-
-
-add_library(alut SHARED ${ALUT_SOURCES} ${ALUT_INTERNAL_HEADERS} ${ALUT_HEADERS})
+add_library(alut ${ALUT_SOURCES} ${ALUT_INTERNAL_HEADERS} ${ALUT_HEADERS})
 set_property(TARGET
 	alut
 	PROPERTY


### PR DESCRIPTION
Single Cmake builds usually only install EITHER shared or static libraries depending on the `BUILD_SHARED_LIBS` option.

In order to build the static version of the library, simply pass Cmake `-DBUILD_SHARED_LIBS=OFF`. Use `-DBUILD_SHARED_LIBS=ON` to build shared libs.

This changes the default from forcing shared libs (that's what the `SHARED` was doing) to using the default of building static libs.